### PR TITLE
Update to newest GlusterFS libs and Go version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,19 @@
-#!/bin/sh -e
+#!/bin/bash -e
+error() {
+  printf '\E[31m'; echo "$@"; printf '\E[0m'
+}
+
+if [[ $EUID -ne 0 ]]; then
+    error "This script should be run using sudo or as the root user"
+    exit 1
+fi
+
 TAG=$1
 build() {
     docker plugin rm -f trajano/$1 || true
     docker rmi -f rootfsimage || true
     docker build -t rootfsimage $1
-    id=$(docker create rootfsimage -h) # id was cd851ce43a403 when the image was created
+    id=$(docker create rootfsimage true) # id was cd851ce43a403 when the image was created
     rm -rf build/rootfs
     mkdir -p build/rootfs
     docker export "$id" | tar -x -C build/rootfs

--- a/centos-mounted-volume-plugin/Dockerfile
+++ b/centos-mounted-volume-plugin/Dockerfile
@@ -1,16 +1,17 @@
 FROM centos/systemd
-RUN yum install -q -q -y go git epel-release yum-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service
+RUN yum install -q -q -y git epel-release yum-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
 COPY centos-mounted-volume-plugin.service /usr/lib/systemd/system/
 COPY init.sh /
 RUN ln -s /usr/lib/systemd/system/centos-mounted-volume-plugin.service /etc/systemd/system/multi-user.target.wants/centos-mounted-volume-plugin.service && \
-  chmod 644 /usr/lib/systemd/system/centos-mounted-volume-plugin.service && \
-  chmod 700 /init.sh
-RUN go get github.com/trajano/docker-volume-plugins/centos-mounted-volume-plugin && \
-  mv $HOME/go/bin/centos-mounted-volume-plugin / && \
-  rm -rf $HOME/go && \
-  yum remove -q -q -y go git gcc && \
-  yum autoremove -q -q -y && \
-  yum clean all && \
-  rm -rf /var/cache/yum /etc/mtab && \
-  find /var/log -type f -delete
+    chmod 644 /usr/lib/systemd/system/centos-mounted-volume-plugin.service && \
+    chmod 700 /init.sh
+RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/centos-mounted-volume-plugin && \
+    mv $HOME/go/bin/centos-mounted-volume-plugin / && \
+    rm -rf $HOME/go /usr/local/go && \
+    yum remove -q -q -y go git gcc && \
+    yum autoremove -q -q -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum /etc/mtab && \
+    find /var/log -type f -delete
 CMD [ "/init.sh" ]

--- a/cifs-volume-plugin/Dockerfile
+++ b/cifs-volume-plugin/Dockerfile
@@ -1,11 +1,11 @@
 FROM oraclelinux:7-slim
 RUN yum install -q -y git cifs-utils tar && \
-  curl --silent -L https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
 RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/cifs-volume-plugin && \
-  mv $HOME/go/bin/cifs-volume-plugin / && \
-  rm -rf $HOME/go /usr/local/go && \
-  yumdb set reason dep git tar && \
-  yum autoremove -y && \
-  yum clean all && \
-  rm -rf /var/cache/yum /etc/mtab && \
-  find /var/log -type f -delete
+    mv $HOME/go/bin/cifs-volume-plugin / && \
+    rm -rf $HOME/go /usr/local/go && \
+    yumdb set reason dep git tar && \
+    yum autoremove -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum /etc/mtab && \
+    find /var/log -type f -delete

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -1,11 +1,12 @@
-FROM centos:7
-RUN yum install -q -y centos-release-gluster312 && \
-  yum install -q -y go git glusterfs glusterfs-fuse attr
-RUN go get github.com/trajano/docker-volume-plugins/glusterfs-volume-plugin && \
-  mv $HOME/go/bin/glusterfs-volume-plugin / && \
-  rm -rf $HOME/go && \
-  yum remove -q -y go git gcc && \
-  yum autoremove -q -y && \
-  yum clean all && \
-  rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
-  rm /var/log/lastlog /var/log/tallylog
+FROM oraclelinux:7-slim
+RUN yum install -q -y oracle-gluster-release-el7 && \
+    yum install -q -y git glusterfs glusterfs-fuse attr && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/glusterfs-volume-plugin && \
+    mv $HOME/go/bin/glusterfs-volume-plugin / && \
+    rm -rf $HOME/go /usr/local/go && \
+    yum remove -q -y git && \
+    yum autoremove -q -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
+    rm /var/log/lastlog /var/log/tallylog

--- a/nfs-volume-plugin/Dockerfile
+++ b/nfs-volume-plugin/Dockerfile
@@ -1,16 +1,17 @@
 FROM centos/systemd
-RUN yum install -q -q -y go git epel-release yum-utils nfs-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service
+RUN yum install -q -q -y git epel-release yum-utils nfs-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
 COPY nfs-volume-plugin.service /usr/lib/systemd/system/
 COPY init.sh /
 RUN ln -s /usr/lib/systemd/system/nfs-volume-plugin.service /etc/systemd/system/multi-user.target.wants/nfs-volume-plugin.service && \
-  chmod 644 /usr/lib/systemd/system/nfs-volume-plugin.service && \
-  chmod 700 /init.sh
-RUN go get github.com/trajano/docker-volume-plugins/nfs-volume-plugin && \
-  mv $HOME/go/bin/nfs-volume-plugin / && \
-  rm -rf $HOME/go && \
-  yum remove -q -q -y go git gcc && \
-  yum autoremove -q -q -y && \
-  yum clean all && \
-  rm -rf /var/cache/yum /etc/mtab && \
-  find /var/log -type f -delete
+    chmod 644 /usr/lib/systemd/system/nfs-volume-plugin.service && \
+    chmod 700 /init.sh
+RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/nfs-volume-plugin && \
+    mv $HOME/go/bin/nfs-volume-plugin / && \
+    rm -rf $HOME/go /usr/local/go && \
+    yum remove -q -q -y git && \
+    yum autoremove -q -q -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum /etc/mtab && \
+    find /var/log -type f -delete
 CMD [ "/init.sh" ]


### PR DESCRIPTION
Hi:
   I made some few changes to use newest:
- Go 1.11.5
- oraclelinux:7-slim instead of Centos on GlusterFS plugin
- gluster-release-el7 on GlusterFS plugin
  and a minor change on build.sh to check sudo or root access on building all drivers.
  GlusterFS plugin was successful tested on:

- Red Hat Enterprise Linux Server release 7.7 (Maipo) (Oracle-Linux-7.7-2019.09.25-0 cloud image)
- glusterfs.x86_64 5.9-1.el7
- docker 18.09.8-ol (plus swarm)

   Thanks for this great volume driver for GlusterFS. Marcelo.