### PR TITLE
FIX #29: use Tini (offiically supported by Docker) to reap defunct glusterfs processes.

### DIFF
--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -1,4 +1,7 @@
 FROM oraclelinux:7-slim
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
 RUN yum install -q -y oracle-gluster-release-el7 && \
     yum install -q -y git glusterfs glusterfs-fuse attr && \
     curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -

--- a/glusterfs-volume-plugin/config.json
+++ b/glusterfs-volume-plugin/config.json
@@ -2,6 +2,8 @@
     "description": "GlusterFS plugin for Docker",
     "documentation": "https://github.com/trajano/docker-volume-plugins/",
     "entrypoint": [
+        "/tini",
+        "--",
         "/glusterfs-volume-plugin"
     ],
     "env": [


### PR DESCRIPTION
Fixes #29.