### PR TITLE
GlusterFS: added SSL and log support.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ TAG=$1
 build() {
     docker plugin rm -f trajano/$1 || true
     docker rmi -f rootfsimage || true
-    docker build -t rootfsimage $1
+    docker build -t rootfsimage -f $1/Dockerfile .
     id=$(docker create rootfsimage true) # id was cd851ce43a403 when the image was created
     rm -rf build/rootfs
     mkdir -p build/rootfs

--- a/centos-mounted-volume-plugin/Dockerfile
+++ b/centos-mounted-volume-plugin/Dockerfile
@@ -1,17 +1,30 @@
-FROM centos/systemd
+FROM centos/systemd AS base
+
 RUN yum install -q -q -y git epel-release yum-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service && \
-    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-COPY centos-mounted-volume-plugin.service /usr/lib/systemd/system/
-COPY init.sh /
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    rm -rf /var/cache/yum /etc/mtab
+
+COPY centos-mounted-volume-plugin/centos-mounted-volume-plugin.service /usr/lib/systemd/system/
+COPY centos-mounted-volume-plugin/init.sh /
+
 RUN ln -s /usr/lib/systemd/system/centos-mounted-volume-plugin.service /etc/systemd/system/multi-user.target.wants/centos-mounted-volume-plugin.service && \
     chmod 644 /usr/lib/systemd/system/centos-mounted-volume-plugin.service && \
     chmod 700 /init.sh
-RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/centos-mounted-volume-plugin && \
-    mv $HOME/go/bin/centos-mounted-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yum remove -q -q -y go git gcc && \
-    yum autoremove -q -q -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum /etc/mtab && \
-    find /var/log -type f -delete
+
+FROM base as dev
+
+RUN yum install -q -q -y git && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    rm -rf /var/cache/yum
+
+COPY centos-mounted-volume-plugin/ /root/go/src/github.com/trajano/docker-volume-plugins/centos-mounted-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/trajano/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/trajano/docker-volume-plugins/centos-mounted-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/centos-mounted-volume-plugin /
+
 CMD [ "/init.sh" ]

--- a/cifs-volume-plugin/Dockerfile
+++ b/cifs-volume-plugin/Dockerfile
@@ -1,11 +1,20 @@
-FROM oraclelinux:7-slim
-RUN yum install -q -y git cifs-utils tar && \
-    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/cifs-volume-plugin && \
-    mv $HOME/go/bin/cifs-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yumdb set reason dep git tar && \
-    yum autoremove -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum /etc/mtab && \
-    find /var/log -type f -delete
+FROM oraclelinux:7-slim as base
+
+RUN yum install -q -y cifs-utils && \
+    rm -rf /var/cache/yum /etc/mtab
+
+FROM base as dev
+
+RUN yum install -q -y git tar && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    rm -rf /var/cache/yum
+
+COPY cifs-volume-plugin/ /root/go/src/github.com/trajano/docker-volume-plugins/cifs-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/trajano/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/trajano/docker-volume-plugins/cifs-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/cifs-volume-plugin /

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -5,11 +5,14 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 RUN yum install -y oracle-gluster-release-el7 && \
-    yum install -y glusterfs glusterfs-fuse attr && \
+    yum install -y glusterfs glusterfs-fuse attr rsyslog && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
     rm /var/log/lastlog /var/log/tallylog && \
-    mkdir /var/lib/glusterd
+    mkdir -p /var/lib/glusterd /etc/glusterfs && \
+    touch /etc/glusterfs/logger.conf
+
+COPY glusterfs-volume-plugin/rsyslog.conf /etc/rsyslog.conf
 
 FROM base as dev
 

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -8,7 +8,8 @@ RUN yum install -y oracle-gluster-release-el7 && \
     yum install -y glusterfs glusterfs-fuse attr && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
-    rm /var/log/lastlog /var/log/tallylog
+    rm /var/log/lastlog /var/log/tallylog && \
+    mkdir /var/lib/glusterd
 
 FROM base as dev
 

--- a/glusterfs-volume-plugin/Dockerfile
+++ b/glusterfs-volume-plugin/Dockerfile
@@ -1,14 +1,26 @@
-FROM oraclelinux:7-slim
-ENV TINI_VERSION v0.18.0
+FROM oraclelinux:7-slim as base
+ARG TINI_VERSION="v0.18.0"
+
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-RUN yum install -q -y oracle-gluster-release-el7 && \
-    yum install -q -y git glusterfs glusterfs-fuse attr && \
-    curl --silent -L https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/glusterfs-volume-plugin && \
-    mv $HOME/go/bin/glusterfs-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yum remove -q -y git && \
+
+RUN yum install -y oracle-gluster-release-el7 && \
+    yum install -y glusterfs glusterfs-fuse attr && \
     yum clean all && \
     rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
     rm /var/log/lastlog /var/log/tallylog
+
+FROM base as dev
+
+RUN curl --silent -L https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    yum install -y git
+
+COPY glusterfs-volume-plugin/ /root/go/src/github.com/trajano/docker-volume-plugins/glusterfs-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/trajano/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/trajano/docker-volume-plugins/glusterfs-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/glusterfs-volume-plugin /

--- a/glusterfs-volume-plugin/README.md
+++ b/glusterfs-volume-plugin/README.md
@@ -76,3 +76,17 @@ This is an example of mounting and testing a store outside the swarm.  It is ass
     docker plugin enable trajano/glusterfs-volume-plugin
     docker volume create -d trajano/glusterfs-volume-plugin --opt servers=store1 trajano
     docker run -it -v trajano:/mnt alpine
+
+## SSL support
+
+Host path `/etc/ssl` is made available to gluster clients so to configure SSL you should follow steps from GlusterFS documentation.
+
+### Management Channel
+
+By default, GlusterFS process will not use SSL to communicate with servers when eg. fetching volume list.
+To secure management channel, set `SECURE_MANAGEMENT` to non empty value, eg.: `docker plugin glusterfs set SECURE_MANAGEMENT=yes`.
+
+Remember that all clients and servers will need to ahve secure management enabled to be able to communicate:
+**(...) will cause glusterd connections made from that machine to use TLS. Note that even clients must do this to communicate with a remote glusterd while mounting, but not thereafter**
+
+More at: https://gluster.readthedocs.io/en/latest/Administrator%20Guide/SSL/#enabling-tls-on-the-management-path

--- a/glusterfs-volume-plugin/config.json
+++ b/glusterfs-volume-plugin/config.json
@@ -13,6 +13,13 @@
                 "value"
             ],
             "value": ""
+        },
+        {
+            "name": "SECURE_MANAGEMENT",
+            "settable": [
+                "value"
+            ],
+            "value": ""
         }
     ],
     "network": {
@@ -34,5 +41,15 @@
                 "path": "/dev/fuse"
             }
         ]
-    }
+    },
+    "mounts": [
+        {
+            "name": "ssl",
+            "source": "/etc/ssl",
+            "description": "",
+            "destination": "/etc/ssl",
+            "type": "bind",
+            "options": ["readonly", "shared", "rbind"]
+        }
+    ]
 }

--- a/glusterfs-volume-plugin/main.go
+++ b/glusterfs-volume-plugin/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/docker/go-plugins-helpers/volume"
@@ -54,6 +55,8 @@ func (p *gfsDriver) MountOptions(req *volume.CreateRequest) []string {
 		args = strings.Split(glusteropts, " ")
 	}
 
+	args = append(args, "--logger=syslog")
+
 	return args
 }
 
@@ -96,8 +99,13 @@ func buildDriver() *gfsDriver {
 	return d
 }
 
+func spawnSyslog() {
+	cmd := exec.Command("rsyslogd", "-n")
+	cmd.Start()
+}
+
 func main() {
-	log.SetFlags(0)
+	spawnSyslog()
 	d := buildDriver()
 	defer d.Close()
 	d.ServeUnix()

--- a/glusterfs-volume-plugin/main.go
+++ b/glusterfs-volume-plugin/main.go
@@ -83,6 +83,15 @@ func buildDriver() *gfsDriver {
 		Driver:  *mountedvolume.NewDriver("glusterfs", true, "gfs", "local"),
 		servers: servers,
 	}
+
+	if os.Getenv("SECURE_MANAGEMENT") != "" {
+		file, err := os.Create("/var/lib/glusterd/secure-access")
+		if err != nil {
+			log.Fatal("Could not create secure-access file: "+err.Error())
+		}
+		defer file.Close()
+	}
+
 	d.Init(d)
 	return d
 }

--- a/glusterfs-volume-plugin/rsyslog.conf
+++ b/glusterfs-volume-plugin/rsyslog.conf
@@ -1,0 +1,16 @@
+$ModLoad imuxsock
+$WorkDirectory /var/lib/rsyslog
+
+template(name="DockerFormat" type="list") {
+    constant(value="glusterfs-volume-plugin: ")
+    property(name="syslogtag")
+    property(name="msg" spifno1stsp="on" )
+    property(name="msg" droplastlf="on" )
+    constant(value="\n")
+}
+
+$ActionFileDefaultTemplate DockerFormat
+$SystemLogSocketName /dev/log
+$LogRSyslogStatusMessages off
+
+*.*                                                 /proc/1/fd/1

--- a/nfs-volume-plugin/Dockerfile
+++ b/nfs-volume-plugin/Dockerfile
@@ -1,17 +1,30 @@
-FROM centos/systemd
-RUN yum install -q -q -y git epel-release yum-utils nfs-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service && \
-    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-COPY nfs-volume-plugin.service /usr/lib/systemd/system/
-COPY init.sh /
+FROM centos/systemd as base
+
+RUN yum install -q -q -y epel-release yum-utils nfs-utils rsyslog dbus && yum makecache fast && systemctl enable rsyslog.service && \
+    rm -rf /var/cache/yum /etc/mtab && \
+    find /var/log -type f -delete
+
+COPY nfs-volume-plugin/nfs-volume-plugin.service /usr/lib/systemd/system/
+COPY nfs-volume-plugin/init.sh /
+
 RUN ln -s /usr/lib/systemd/system/nfs-volume-plugin.service /etc/systemd/system/multi-user.target.wants/nfs-volume-plugin.service && \
     chmod 644 /usr/lib/systemd/system/nfs-volume-plugin.service && \
     chmod 700 /init.sh
-RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/nfs-volume-plugin && \
-    mv $HOME/go/bin/nfs-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yum remove -q -q -y git && \
-    yum autoremove -q -q -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum /etc/mtab && \
-    find /var/log -type f -delete
+
+FROM base as dev
+
+RUN yum install -q -q -y git && \
+    curl --silent -L https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -C /usr/local -zxf - && \
+    rm -rf /var/cache/yum
+
+COPY nfs-volume-plugin/ /root/go/src/github.com/trajano/docker-volume-plugins/nfs-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/trajano/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/trajano/docker-volume-plugins/nfs-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/nfs-volume-plugin /
+
 CMD [ "/init.sh" ]

--- a/s3fs-volume-plugin/Dockerfile
+++ b/s3fs-volume-plugin/Dockerfile
@@ -1,14 +1,25 @@
-FROM oraclelinux:7-slim
-ENV TINI_VERSION v0.18.0
+FROM oraclelinux:7-slim AS base
+ARG TINI_VERSION="v0.18.0"
+
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+
 RUN chmod +x /tini
-RUN yum install -q -y oracle-epel-release-el7
-RUN yum install -q -y git fuse s3fs-fuse attr && \
+RUN yum install -q -y oracle-epel-release-el7 && \
+    yum install -q -y fuse s3fs-fuse attr && \
+    rm -rf /var/cache/yum /etc/mtab
+
+FROM base as dev
+
+RUN yum install -q -y git && \
+    rm -rf /var/cache/yum && \
     curl --silent -L https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz | tar -C /usr/local -zxf -
-RUN /usr/local/go/bin/go get github.com/trajano/docker-volume-plugins/s3fs-volume-plugin && \
-    mv $HOME/go/bin/s3fs-volume-plugin / && \
-    rm -rf $HOME/go /usr/local/go && \
-    yum remove -q -y git && \
-    yum clean all && \
-    rm -rf /var/cache/yum /var/log/anaconda /var/cache/yum /etc/mtab && \
-    rm /var/log/lastlog /var/log/tallylog
+
+COPY s3fs-volume-plugin/ /root/go/src/github.com/trajano/docker-volume-plugins/s3fs-volume-plugin
+COPY mounted-volume/ /root/go/src/github.com/trajano/docker-volume-plugins/mounted-volume
+
+RUN cd /root/go/src/github.com/trajano/docker-volume-plugins/s3fs-volume-plugin && \
+    /usr/local/go/bin/go get
+
+FROM base
+
+COPY --from=dev /root/go/bin/s3fs-volume-plugin /


### PR DESCRIPTION
Based on changes in #40 (since there is some Dockerfile changes and 50% chance that one or other PR would be merged first :) )

I've added SSL support (clients and/or secure management channel) and logging for gluster clients to see whats happening inside.

Logs are prefixed with `glusterfs-volume-plugin` and visible on host like:

```
Oct 01 12:06:50 snipsnip dockerd[954]: time="2020-10-01T12:06:50+02:00" level=info msg="glusterfs-volume-plugin:
var-lib-docker-volumes-db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a[87]: [fuse-bridge.c:6088:fuse_thread_proc] 0-f
use: initating unmount of /var/lib/docker-volumes/db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a" plugin=08e3c146cd5
b7328cf1f12a9713b616d1b2a56568544542c9616ab7c3b801fe9
Oct 01 12:06:50 snipsnip dockerd[954]: time="2020-10-01T12:06:50+02:00" level=info msg="glusterfs-volume-plugin:
var-lib-docker-volumes-db0c4032bfb1f9dc1f284987f6b20be9a711157a27a29bfcbcf0fd7afdd65b7a[87]: [glusterfsd.c:1570:cleanup_and_exit] (-->
/lib64/libpthread.so.0(+0x7ea5) [0x7f09d244aea5] -->glusterfs(glusterfs_sigwaiter+0xe5) [0x5589c33a61f5] -->glusterfs(cleanup_and_exit
+0x6b) [0x5589c33a605b] ) 0-: received signum (15), shutting down" plugin=08e3c146cd5b7328cf1f12a9713b616d1b2a56568544542c9616ab7c3b80
1fe9
```